### PR TITLE
Fixed permanent ssh add

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+#ignore the brief.txt
+brief.txt

--- a/setup_ssh_auto.sh
+++ b/setup_ssh_auto.sh
@@ -48,7 +48,7 @@ ssh-copy-id -i "${KEY_PATH}.pub" -p "$SERVER_PORT" "$SERVER_USER@$SERVER_HOST"
 # --- 3. Add key to ssh-agent ---
 echo "Adding key to ssh-agent..."
 # eval "$(ssh-agent -s)"
-ssh-add "$KEY_PATH"
+ssh-add --apple-use-keychain "$KEY_PATH"
 
 # --- 4. (Optional) Create SSH config entry ---
 if [ ! -z "$SSH_ALIAS" ]; then    
@@ -63,6 +63,8 @@ Host $SSH_ALIAS
   HostName $SERVER_HOST
   User $SERVER_USER
   Port $SERVER_PORT
+  UseKeychain yes
+  AddKeysToAgent yes
   IdentityFile $KEY_PATH
 EOL
     else


### PR DESCRIPTION
Apple ssh-add needs a flag --apple-use-keychain. This flag was added to the ssh-add command in the script.

What this does is store the passphrase in the apple keychain so that after reboot it can be used.